### PR TITLE
chore: add deploy script to copy build output to local vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "validate": "bun run scripts/validate-plugin.ts",
+    "deploy": "cp dist/main.js manifest.json styles.css ~/source/mine/notes/.obsidian/plugins/periodic-notes/",
     "test": "bun test",
     "version": "bun run version-bump.ts"
   },


### PR DESCRIPTION
## Summary
- Adds a `deploy` npm script that copies `dist/main.js`, `manifest.json`, and `styles.css` to the local Obsidian vault plugin directory for testing

## Test plan
- [x] `bun run check` passes
- [ ] `bun run build && bun run deploy` copies files to vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)