### PR TITLE
Fix unsafe type cast of getAbstractFileByPath result

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -253,7 +253,6 @@ export class PeriodicNotesCache extends Component {
         const file = this.app.vault.getAbstractFileByPath(filePath);
         if (file instanceof TFile) return file;
         this.cachedFiles.delete(filePath);
-        return null;
       }
     }
     return null;


### PR DESCRIPTION
## Summary
- Replace `as TFolder` cast with `instanceof` guard in `initialize()`
- Replace `as TFile` cast with `instanceof` narrowing in `getPeriodicNote()`
- Prevents runtime errors when paths don't resolve to expected types

Closes #24

## Test plan
- [ ] Verify plugin loads and initializes cache without errors
- [ ] Verify periodic notes are found and opened correctly
- [ ] Verify behavior when configured folder doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)