### PR TITLE
Add null guard on inputEl in Svelte effects

### DIFF
--- a/src/settings/components/NoteFolderSetting.svelte
+++ b/src/settings/components/NoteFolderSetting.svelte
@@ -22,6 +22,7 @@
   }
 
   $effect(() => {
+    if (!inputEl) return;
     error = validateFolder(app, inputEl.value);
     const suggest = new FolderSuggest(app, inputEl);
     return () => suggest.close();

--- a/src/settings/components/NoteFormatSetting.svelte
+++ b/src/settings/components/NoteFormatSetting.svelte
@@ -17,6 +17,7 @@
   let value = $derived($config.format || "");
 
   $effect(() => {
+    if (!inputEl) return;
     error = validateFormat(inputEl.value, granularity);
     warning = validateFormatComplexity(inputEl.value, granularity);
   });

--- a/src/settings/components/NoteTemplateSetting.svelte
+++ b/src/settings/components/NoteTemplateSetting.svelte
@@ -23,6 +23,7 @@
   }
 
   $effect(() => {
+    if (!inputEl) return;
     error = validateTemplate(app, inputEl.value);
     const suggest = new FileSuggest(app, inputEl);
     return () => suggest.close();


### PR DESCRIPTION
## Summary
- Add `if (!inputEl) return` guard in `$effect` blocks for NoteFolderSetting, NoteFormatSetting, and NoteTemplateSetting
- `$effect` can run before `bind:this` assigns the element ref, causing runtime errors

Closes #28

## Test plan
- [ ] Open plugin settings and verify all three setting inputs render without errors
- [ ] Verify folder suggest, file suggest, and format validation still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)