### PR TITLE
refactor: rename monthStart to periodStart in quarter/year transforms

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,7 +128,7 @@ export function applyTemplateTransformations(
       /{{\s*(quarter)\s*(([+-]\d+)([yqmwdhs]))?\s*(:.+?)?}}/gi,
       (_, _timeOrDate, calc, timeDelta, unit, momentFormat) => {
         const now = window.moment();
-        const monthStart = date
+        const periodStart = date
           .clone()
           .startOf("quarter")
           .set({
@@ -137,13 +137,13 @@ export function applyTemplateTransformations(
             second: now.get("second"),
           });
         if (calc) {
-          monthStart.add(parseInt(timeDelta, 10), unit);
+          periodStart.add(parseInt(timeDelta, 10), unit);
         }
 
         if (momentFormat) {
-          return monthStart.format(momentFormat.substring(1).trim());
+          return periodStart.format(momentFormat.substring(1).trim());
         }
-        return monthStart.format(format);
+        return periodStart.format(format);
       },
     );
   }
@@ -153,7 +153,7 @@ export function applyTemplateTransformations(
       /{{\s*(year)\s*(([+-]\d+)([yqmwdhs]))?\s*(:.+?)?}}/gi,
       (_, _timeOrDate, calc, timeDelta, unit, momentFormat) => {
         const now = window.moment();
-        const monthStart = date
+        const periodStart = date
           .clone()
           .startOf("year")
           .set({
@@ -162,13 +162,13 @@ export function applyTemplateTransformations(
             second: now.get("second"),
           });
         if (calc) {
-          monthStart.add(parseInt(timeDelta, 10), unit);
+          periodStart.add(parseInt(timeDelta, 10), unit);
         }
 
         if (momentFormat) {
-          return monthStart.format(momentFormat.substring(1).trim());
+          return periodStart.format(momentFormat.substring(1).trim());
         }
-        return monthStart.format(format);
+        return periodStart.format(format);
       },
     );
   }


### PR DESCRIPTION
## Summary

- Renames misleading `monthStart` variable to `periodStart` in the quarter and year template transform blocks in `src/utils.ts`
- The variable holds the start of a quarter or year, not a month — the new name reflects actual semantics

Closes #12

## Test plan

- [x] All existing tests pass (34/34)
- [x] TypeScript type check clean
- [x] Biome lint/format clean
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)