### PR TITLE
refactor: narrow setConfig value type from any to VaultSettings[T]

### DIFF
--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -25,8 +25,10 @@ declare module "obsidian" {
   interface Vault {
     config: Record<string, unknown>;
     getConfig<T extends keyof VaultSettings>(setting: T): VaultSettings[T];
-    // biome-ignore lint/suspicious/noExplicitAny: Obsidian API lacks type
-    setConfig<T extends keyof VaultSettings>(setting: T, value: any): void;
+    setConfig<T extends keyof VaultSettings>(
+      setting: T,
+      value: VaultSettings[T],
+    ): void;
   }
 
   export interface PluginInstance {


### PR DESCRIPTION
## Summary
- Replace `value: any` with `value: VaultSettings[T]` on the `setConfig` type declaration, fully constraining the generic
- Remove the associated biome-ignore comment (no longer needed)

## Changes
- `src/obsidian.d.ts:29` — narrow the value parameter type

## Notes
The two `ctx?: any` parameters on `Workspace.on()` match Obsidian's own upstream type (`Events.on` uses `ctx?: any`) and are left as-is.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)