### PR TITLE
refactor: centralize test global mocks via Bun preload

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-setup.ts"]

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -3,9 +3,6 @@ import moment from "moment";
 
 import { type Granularity, granularities } from "./types";
 
-// @ts-expect-error global mock
-globalThis.window = { moment };
-
 // Re-implement cache data types and pure logic
 
 type MatchType = "filename" | "frontmatter" | "date-prefixed";

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import moment from "moment";
 
 import { getLooselyMatchedDate } from "./parser";
-
-// @ts-expect-error global mock
-globalThis.window = { moment };
 
 describe("getLooselyMatchedDate", () => {
   test("matches YYYY-MM-DD format", () => {

--- a/src/settings/localization.test.ts
+++ b/src/settings/localization.test.ts
@@ -1,15 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import moment from "moment";
 
-// @ts-expect-error global mock
-globalThis.window = { moment };
-
-// @ts-expect-error global mock
+// @ts-expect-error partial localStorage mock for localization tests
 globalThis.localStorage = {
   getItem: () => "en",
 };
 
-// @ts-expect-error global mock
+// @ts-expect-error partial navigator mock for localization tests
 globalThis.navigator = {
   language: "en-US",
 };

--- a/src/settings/utils.test.ts
+++ b/src/settings/utils.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import moment from "moment";
 
 import { DEFAULT_PERIODIC_CONFIG } from "../constants";
 import { type Granularity, granularities, type PeriodicConfig } from "../types";
-
-// @ts-expect-error global mock
-globalThis.window = {
-  moment,
-  _bundledLocaleWeekSpec: { dow: 0, doy: 6 },
-};
 
 type Settings = Record<Granularity, PeriodicConfig | undefined>;
 

--- a/src/settings/validation.test.ts
+++ b/src/settings/validation.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import moment from "moment";
 
 import type { Granularity } from "../types";
-
-// @ts-expect-error global mock
-globalThis.window = { moment };
 
 // Re-implement pure functions to avoid obsidian imports
 

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,7 @@
+import moment from "moment";
+
+// @ts-expect-error partial window mock for test environment
+globalThis.window = {
+  moment,
+  _bundledLocaleWeekSpec: { dow: 0, doy: 6 },
+};

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -14,10 +14,6 @@ function removeEscapedCharacters(format: string): string {
   return withoutBrackets.replace(/\\./g, "");
 }
 
-// Provide window.moment for code that uses it
-// @ts-expect-error global mock
-globalThis.window = { moment };
-
 // Re-implement pure functions to test without Obsidian imports
 
 function join(...partSegments: string[]): string {


### PR DESCRIPTION
## Summary
- Add `src/test-setup.ts` preload with shared `window.moment` and `_bundledLocaleWeekSpec` mocks
- Add `bunfig.toml` with `[test] preload` config
- Remove repeated `@ts-expect-error global mock` boilerplate from 6 test files (8 suppressions → 3)

## Changes
- **New:** `src/test-setup.ts` — centralized test global setup
- **New:** `bunfig.toml` — Bun test configuration
- **Modified:** `src/parser.test.ts`, `src/cache.test.ts`, `src/utils.test.ts`, `src/settings/validation.test.ts`, `src/settings/localization.test.ts`, `src/settings/utils.test.ts` — removed mock boilerplate

## Notes
The 2 remaining `@ts-expect-error` in `localization.test.ts` are for `localStorage` and `navigator` mocks specific to that test file.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)