### PR TITLE
docs: document private API access pattern for SuggestModal.chooser

### DIFF
--- a/src/switcher/switcher.ts
+++ b/src/switcher/switcher.ts
@@ -38,6 +38,9 @@ export class NLDNavigator extends SuggestModal<DateNavigationItem> {
       "nldates-obsidian",
     ) as NLDatesPlugin;
 
+    // SuggestModal.chooser is a private Obsidian API — not in the type
+    // definitions but available at runtime. Wrapped in try-catch so the
+    // plugin degrades gracefully if Obsidian removes or renames it.
     this.scope.register(["Meta"], "Enter", (evt: KeyboardEvent) => {
       try {
         // @ts-expect-error this.chooser exists but is not exposed
@@ -64,6 +67,7 @@ export class NLDNavigator extends SuggestModal<DateNavigationItem> {
     });
   }
 
+  // Private Obsidian API — see comment on chooser.useSelectedItem above.
   private getSelectedItem(): DateNavigationItem | undefined {
     try {
       // biome-ignore lint/suspicious/noExplicitAny: Obsidian API lacks type


### PR DESCRIPTION
## Summary
- Add code comments explaining why `SuggestModal.chooser` access uses `@ts-expect-error`, `as any`, and try-catch
- Documents the private Obsidian API contract and graceful degradation strategy

## Changes
- `src/switcher/switcher.ts` — 2 comment blocks added (lines 41-43 and 70)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)