### PR TITLE
docs: document store counter and subscription bridge patterns

### DIFF
--- a/src/calendar/Calendar.svelte
+++ b/src/calendar/Calendar.svelte
@@ -39,6 +39,8 @@
     month = getMonth($displayedMonthStore);
   });
 
+  // $derived.by() doesn't track Svelte store subscriptions,
+  // so we manually subscribe inside $effect and return the unsubscribe.
   $effect(() => {
     const currentMonth = month;
     return fileStore.store.subscribe(() => {

--- a/src/calendar/fileStore.ts
+++ b/src/calendar/fileStore.ts
@@ -7,6 +7,8 @@ import { get, type Writable, writable } from "svelte/store";
 import type { FileMap, IMonth } from "./types";
 
 export default class CalendarFileStore {
+  // Svelte 5 runes don't track store auto-subscriptions.
+  // Bumping a counter triggers subscribers to re-read plugin state.
   public store: Writable<number>;
   private plugin: PeriodicNotesPlugin;
 


### PR DESCRIPTION
## Summary

- Add inline comment on the counter-bump store in `fileStore.ts` explaining the Svelte 5 runes workaround
- Add inline comment on the effect-wrapping subscription in `Calendar.svelte` explaining the manual subscribe pattern

Comments only, no behavioral changes.

Closes #90

## Test plan

- [x] `bun run check` passes
- [x] `bun test` — all 159 tests pass
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)